### PR TITLE
Basic support for Tripal 3

### DIFF
--- a/includes/TripalFields/local__go_results/local__go_results.inc
+++ b/includes/TripalFields/local__go_results/local__go_results.inc
@@ -110,9 +110,30 @@ class local__go_results extends ChadoField {
     // default settings above. If that is all you need then you don't even
     // need to implement this function. However, if you need to add any
     // additional data to be used in the display, you should add it here.
-    parent::load($entity);
-  }
 
+
+    
+    $field_name = $this->field['field_name'];
+    // Cleanup existing data 
+    unset($entity->{$field_name}['und'][0]);
+    $organism_id = $entity->chado_record->organism_id;
+
+    $sql = "
+      SELECT *
+      FROM {go_count_analysis} GO, {analysis} a
+      WHERE organism_id = :organism_id
+      AND GO.analysis_id = a.analysis_id
+      ORDER BY GO.analysis_id DESC
+    ";
+
+    $results = chado_query($sql, array(':organism_id' => $organism_id));
+    // If $entity->{$field_name}['und'] is empty, the field is not shown
+    // Set data for blank option and to avoid an empty field
+    $entity->{$field_name}['und'][0][''] = '';
+    while ($analysis = $results->fetchObject()) {
+        $entity->{$field_name}['und'][0][$analysis->analysis_id."-".$organism_id] = "$analysis->name";   
+    }
+  }
 
 
     /**

--- a/includes/TripalFields/local__go_results/local__go_results.inc
+++ b/includes/TripalFields/local__go_results/local__go_results.inc
@@ -1,0 +1,153 @@
+<?php
+/**
+ * @class
+ * Purpose:
+ *
+ * Data:
+ * Assumptions:
+ */
+class local__go_results extends ChadoField {
+
+  // --------------------------------------------------------------------------
+  //                     EDITABLE STATIC CONSTANTS
+  //
+  // The following constants SHOULD be set for each descendant class.  They are
+  // used by the static functions to provide information to Drupal about
+  // the field and it's default widget and formatter.
+  // --------------------------------------------------------------------------
+
+  // The default label for this field.
+  public static $default_label = 'Go results';
+
+  // The default description for this field.
+  public static $default_description = 'Go results';
+
+  // The default widget for this field.
+  public static $default_widget = 'local__go_results_widget';
+
+  // The default formatter for this field.
+  public static $default_formatter = 'local__go_results_formatter';
+
+  // The module that manages this field.
+  // If no module manages the field (IE it's added via libraries)
+  // set this to 'tripal_chado'
+  public static $module = 'tripal_analysis_go';
+
+  // A list of global settings. These can be accessed within the
+  // globalSettingsForm.  When the globalSettingsForm is submitted then
+  // Drupal will automatically change these settings for all fields.
+  // Once instances exist for a field type then these settings cannot be
+  // changed.
+  public static $default_settings = array(
+    'storage' => 'field_chado_storage',
+     // It is expected that all fields set a 'value' in the load() function.
+     // In many cases, the value may be an associative array of key/value pairs.
+     // In order for Tripal to provide context for all data, the keys should
+     // be a controlled vocabulary term (e.g. rdfs:type). Keys in the load()
+     // function that are supported by the query() function should be
+     // listed here.
+     'searchable_keys' => array(),
+  );
+
+  // Indicates the download formats for this field.  The list must be the
+  // name of a child class of the TripalFieldDownloader.
+  public static $download_formatters = array(
+     'TripalTabDownloader',
+     'TripalCSVDownloader',
+  );
+
+  // Provide a list of instance specific settings. These can be access within
+  // the instanceSettingsForm.  When the instanceSettingsForm is submitted
+  // then Drupal with automatically change these settings for the instance.
+  // It is recommended to put settings at the instance level whenever possible.
+  // If you override this variable in a child class be sure to replicate the
+  // term_name, term_vocab, term_accession and term_fixed keys as these are
+  // required for all TripalFields.
+  public static $default_instance_settings = array(
+    // The DATABASE name, as it appears in chado.db.  This also builds the link-out url.  In most cases this will simply be the CV name.  In some cases (EDAM) this will be the SUBONTOLOGY.
+    'term_vocabulary' => 'local',
+    // The name of the term.
+    'term_name' => 'Go results',
+    // The unique ID (i.e. accession) of the term.
+    'term_accession' => 'go_results',
+    // Set to TRUE if the site admin is not allowed to change the term
+    // type, otherwise the admin can change the term mapped to a field.
+    'term_fixed' => FALSE,
+    // Indicates if this field should be automatically attached to display
+    // or web services or if this field should be loaded separately. This
+    // is convenient for speed.  Fields that are slow should for loading
+    // should have auto_attach set to FALSE so tha their values can be
+    // attached asynchronously.
+    'auto_attach' => FALSE,
+    // The table in Chado that the instance maps to.
+    'chado_table' => '',
+    // The column of the table in Chado where the value of the field comes from.
+    'chado_column' => '',
+    // The base table.
+    'base_table' => '',
+  );
+
+  // A boolean specifying that users should not be allowed to create
+  // fields and instances of this field type through the UI. Such
+  // fields can only be created programmatically with field_create_field()
+  // and field_create_instance().
+  public static $no_ui = FALSE;
+
+  // A boolean specifying that the field will not contain any data. This
+  // should exclude the field from web services or downloads.  An example
+  // could be a quick search field that appears on the page that redirects
+  // the user but otherwise provides no data.
+  public static $no_data = FALSE;
+
+   /**
+    * @see ChadoField::load()
+    *
+    **/
+
+  public function load($entity) {
+
+    // ChadoFields automatically load the chado column specified in the
+    // default settings above. If that is all you need then you don't even
+    // need to implement this function. However, if you need to add any
+    // additional data to be used in the display, you should add it here.
+    parent::load($entity);
+  }
+
+
+
+    /**
+    * @see ChadoField::query()
+    *
+    **/
+
+  public function query($query, $condition) {
+  }
+
+    /**
+    * @see ChadoField::queryOrder()
+    *
+    **/
+
+  public function queryOrder($query, $order) {
+  }
+
+
+    /**
+    * @see ChadoField::elementInfo()
+    *
+    **/
+    
+  public function elementInfo() {
+    $field_term = $this->getFieldTermID();
+    return array(
+      $field_term => array(
+        'operations' => array('eq', 'ne', 'contains', 'starts'),
+        'sortable' => TRUE,
+        'searchable' => TRUE,
+      ),
+    );
+  }
+
+}
+
+

--- a/includes/TripalFields/local__go_results/local__go_results_formatter.inc
+++ b/includes/TripalFields/local__go_results/local__go_results_formatter.inc
@@ -49,7 +49,7 @@ class local__go_results_formatter extends ChadoFieldFormatter {
       ->execute()->fetchField();
 
     if(user_access('view ' . $bundle_id)){
-      $form = drupal_get_form('tripal_analysis_go_select_form', $organism_id);
+      $form = drupal_get_form('tripal_analysis_go_select_form', null, $organism_id);
       $content = drupal_render($form);
 
       $content .= '

--- a/includes/TripalFields/local__go_results/local__go_results_formatter.inc
+++ b/includes/TripalFields/local__go_results/local__go_results_formatter.inc
@@ -1,0 +1,66 @@
+<?php
+/**
+ * @class
+ * Purpose:
+ *
+ * Display:
+ * Configuration:
+ */
+class local__go_results_formatter extends ChadoFieldFormatter {
+
+  // The default label for this field.
+  public static $default_label = 'Go results';
+
+  // The list of field types for which this formatter is appropriate.
+  public static $field_types = array('local__go_results');
+
+  // The list of default settings for this formatter.
+  public static $default_settings = array(
+    'setting1' => 'default_value',
+  );
+
+   /**
+    * @see ChadoFieldFormatter::settingsForm()
+    *
+    **/
+
+  public function settingsForm($view_mode, $form, &$form_state) {
+
+  }
+
+    /**
+    * @see ChadoFieldFormatter::View()
+    *
+    **/
+
+  public function view(&$element, $entity_type, $entity, $langcode, $items, $display) {
+
+    // Get the settings
+    $settings = $display['settings'];
+
+    $organism_id = $entity->chado_record->organism_id;
+
+    $form = drupal_get_form('tripal_analysis_go_select_form', $organism_id);
+    $content = drupal_render($form);
+    $content .= '<div id="tripal_analysis_go_org_charts"></div>';
+    $content .= '<div id="tripal_cv_cvterm_info_box">';
+    $content .= '<a href="#" onclick="jQuery("#tripal_cv_cvterm_info_box").hide(); return false;" style="float: right">Close [X]</a>';
+    $content .= '<div>Term Information</div>';
+    $content .= '<div id="tripal_cv_cvterm_info"></div></div>';
+    $element[] = [
+      '#type' => 'markup',
+      '#markup' => $content,
+    ];
+    return $element;
+  }
+
+    /**
+    * @see ChadoFieldFormatter::settingsSummary()
+    *
+    **/
+
+  public function settingsSummary($view_mode) {
+    return '';
+  }
+
+}

--- a/includes/TripalFields/local__go_results/local__go_results_formatter.inc
+++ b/includes/TripalFields/local__go_results/local__go_results_formatter.inc
@@ -35,21 +35,21 @@ class local__go_results_formatter extends ChadoFieldFormatter {
 
   public function view(&$element, $entity_type, $entity, $langcode, $items, $display) {
 
-    // Get the settings
-    $settings = $display['settings'];
+    if(count($items[0]) == 1){
+        $content= "There are no analyses with Go results available for this organism.";
+    }
+    else {
+      $form = drupal_get_form('tripal_analysis_go_select_form', null, $items[0]);
+      $content = drupal_render($form);
 
-    $organism_id = $entity->chado_record->organism_id;
-
-    $form = drupal_get_form('tripal_analysis_go_select_form', null, $organism_id);
-    $content = drupal_render($form);
-
-    $content .= '
-      <div id="tripal_analysis_go_org_charts"></div>
-      <div id="tripal_cv_cvterm_info_box">
-      <a href="#" onclick="jQuery(\'#tripal_cv_cvterm_info_box\').hide(); return false;" style="float: right">Close [X]</a>
-      <div>Term Information</div>
-      <div id="tripal_cv_cvterm_info"></div></div>
-    ';
+      $content .= '
+        <div id="tripal_analysis_go_org_charts"></div>
+        <div id="tripal_cv_cvterm_info_box">
+        <a href="#" onclick="jQuery(\'#tripal_cv_cvterm_info_box\').hide(); return false;" style="float: right">Close [X]</a>
+        <div>Term Information</div>
+        <div id="tripal_cv_cvterm_info"></div></div>
+      ';
+    }
     $element[] = [
       '#type' => 'markup',
       '#markup' => $content,

--- a/includes/TripalFields/local__go_results/local__go_results_formatter.inc
+++ b/includes/TripalFields/local__go_results/local__go_results_formatter.inc
@@ -52,14 +52,6 @@ class local__go_results_formatter extends ChadoFieldFormatter {
       $form = drupal_get_form('tripal_analysis_go_select_form', $organism_id);
       $content = drupal_render($form);
 
-     /*
-      $content .= '<div id="tripal_analysis_go_org_charts"></div>';
-      $content .= '<div id="tripal_cv_cvterm_info_box">';
-      $content .= '<a href="#" onclick="jQuery("#tripal_cv_cvterm_info_box").hide(); return false;" style="float: right">Close [X]</a>';
-      $content .= '<div>Term Information</div>';
-      $content .= '<div id="tripal_cv_cvterm_info"></div></div>';
-     */
-
       $content .= '
         <div id="tripal_analysis_go_org_charts"></div>
         <div id="tripal_cv_cvterm_info_box">

--- a/includes/TripalFields/local__go_results/local__go_results_formatter.inc
+++ b/includes/TripalFields/local__go_results/local__go_results_formatter.inc
@@ -40,30 +40,21 @@ class local__go_results_formatter extends ChadoFieldFormatter {
 
     $organism_id = $entity->chado_record->organism_id;
 
-    // Check for permission to see Analysis entity
+    $form = drupal_get_form('tripal_analysis_go_select_form', null, $organism_id);
+    $content = drupal_render($form);
 
-    $query = db_select('public.tripal_bundle', 'tb');
-    $query->join('tripal_term', 'tt', 'tt.id = tb.term_id');
-    $bundle_id = $query->fields('tb', ['name'])
-      ->condition('tt.name', 'Analysis')
-      ->execute()->fetchField();
+    $content .= '
+      <div id="tripal_analysis_go_org_charts"></div>
+      <div id="tripal_cv_cvterm_info_box">
+      <a href="#" onclick="jQuery(\'#tripal_cv_cvterm_info_box\').hide(); return false;" style="float: right">Close [X]</a>
+      <div>Term Information</div>
+      <div id="tripal_cv_cvterm_info"></div></div>
+    ';
+    $element[] = [
+      '#type' => 'markup',
+      '#markup' => $content,
+    ];
 
-    if(user_access('view ' . $bundle_id)){
-      $form = drupal_get_form('tripal_analysis_go_select_form', null, $organism_id);
-      $content = drupal_render($form);
-
-      $content .= '
-        <div id="tripal_analysis_go_org_charts"></div>
-        <div id="tripal_cv_cvterm_info_box">
-        <a href="#" onclick="jQuery(\'#tripal_cv_cvterm_info_box\').hide(); return false;" style="float: right">Close [X]</a>
-        <div>Term Information</div>
-        <div id="tripal_cv_cvterm_info"></div></div>
-      ';
-      $element[] = [
-        '#type' => 'markup',
-        '#markup' => $content,
-      ];
-    }
     return $element;
 
   }

--- a/includes/TripalFields/local__go_results/local__go_results_formatter.inc
+++ b/includes/TripalFields/local__go_results/local__go_results_formatter.inc
@@ -40,18 +40,40 @@ class local__go_results_formatter extends ChadoFieldFormatter {
 
     $organism_id = $entity->chado_record->organism_id;
 
-    $form = drupal_get_form('tripal_analysis_go_select_form', $organism_id);
-    $content = drupal_render($form);
-    $content .= '<div id="tripal_analysis_go_org_charts"></div>';
-    $content .= '<div id="tripal_cv_cvterm_info_box">';
-    $content .= '<a href="#" onclick="jQuery("#tripal_cv_cvterm_info_box").hide(); return false;" style="float: right">Close [X]</a>';
-    $content .= '<div>Term Information</div>';
-    $content .= '<div id="tripal_cv_cvterm_info"></div></div>';
-    $element[] = [
-      '#type' => 'markup',
-      '#markup' => $content,
-    ];
+    // Check for permission to see Analysis entity
+
+    $query = db_select('public.tripal_bundle', 'tb');
+    $query->join('tripal_term', 'tt', 'tt.id = tb.term_id');
+    $bundle_id = $query->fields('tb', ['name'])
+      ->condition('tt.name', 'Analysis')
+      ->execute()->fetchField();
+
+    if(user_access('view ' . $bundle_id)){
+      $form = drupal_get_form('tripal_analysis_go_select_form', $organism_id);
+      $content = drupal_render($form);
+
+     /*
+      $content .= '<div id="tripal_analysis_go_org_charts"></div>';
+      $content .= '<div id="tripal_cv_cvterm_info_box">';
+      $content .= '<a href="#" onclick="jQuery("#tripal_cv_cvterm_info_box").hide(); return false;" style="float: right">Close [X]</a>';
+      $content .= '<div>Term Information</div>';
+      $content .= '<div id="tripal_cv_cvterm_info"></div></div>';
+     */
+
+      $content .= '
+        <div id="tripal_analysis_go_org_charts"></div>
+        <div id="tripal_cv_cvterm_info_box">
+        <a href="#" onclick="jQuery(\'#tripal_cv_cvterm_info_box\').hide(); return false;" style="float: right">Close [X]</a>
+        <div>Term Information</div>
+        <div id="tripal_cv_cvterm_info"></div></div>
+      ';
+      $element[] = [
+        '#type' => 'markup',
+        '#markup' => $content,
+      ];
+    }
     return $element;
+
   }
 
     /**

--- a/includes/TripalFields/local__go_results/local__go_results_widget.inc
+++ b/includes/TripalFields/local__go_results/local__go_results_widget.inc
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @class
+ * Purpose:
+ *
+ * Allowing edit?
+ * Data:
+ * Assumptions:
+ */
+class local__go_results_widget extends ChadoFieldWidget {
+
+  // The default label for this field.
+  public static $default_label = 'Go results';
+
+  // The list of field types for which this formatter is appropriate.
+  public static $field_types = array('local__go_results');
+
+
+ /**
+  * @see ChadoFieldWidget::form()
+  *
+  **/
+
+  public function form(&$widget, &$form, &$form_state, $langcode, $items, $delta, $element) {
+    parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
+  }
+
+  /**
+  * @see ChadoFieldWidget::validate()
+  *
+  **/
+  public function validate($element, $form, &$form_state, $langcode, $delta) {
+  }
+
+   /**
+  * @see ChadoFieldWidget::submit()
+  *
+  **/
+  public function submit($form, &$form_state, $entity_type, $entity, $langcode, $delta) {
+  }
+
+}

--- a/includes/tripal_analysis_go.fields.inc
+++ b/includes/tripal_analysis_go.fields.inc
@@ -39,6 +39,9 @@ function tripal_analysis_go_bundle_fields_info($entity_type, $bundle) {
   // Because we are expecting data housed in Chado we can use the 'data_table'
   // property of the bundle to determine if this bundle is really the one
   // we want the field to be associated with.
+
+  if (isset($bundle->data_table) AND ($bundle->data_table == 'organism')) {
+
     // First add my term.
     tripal_insert_cvterm(array(
       'id' => 'local:go_results',
@@ -46,7 +49,7 @@ function tripal_analysis_go_bundle_fields_info($entity_type, $bundle) {
       'cv_name' => 'local',
       'definition' => 'Go results',
     ));
-
+    
     // Then describe the field defined by that term.
     $field_name = 'local__go_results';
     $field_type = 'local__go_results';
@@ -59,7 +62,8 @@ function tripal_analysis_go_bundle_fields_info($entity_type, $bundle) {
         'type' => 'field_chado_storage',
       ),
     );
-
+  }
+   
   return $fields;
 }
 
@@ -87,7 +91,7 @@ function tripal_analysis_go_bundle_fields_info($entity_type, $bundle) {
  */
 function tripal_analysis_go_bundle_instances_info($entity_type, $bundle) {
   $instances = array();
-
+  if (isset($bundle->data_table) AND ($bundle->data_table == 'organism')) {
     $field_name = 'local__go_results';
     $field_type = 'local__go_results';
     $instances[$field_name] =  array(
@@ -118,6 +122,6 @@ function tripal_analysis_go_bundle_instances_info($entity_type, $bundle) {
         ),
       ),
     );
-
+  }
   return $instances;
 }

--- a/includes/tripal_analysis_go.fields.inc
+++ b/includes/tripal_analysis_go.fields.inc
@@ -1,0 +1,123 @@
+<?php
+/**
+ * @file
+ * Contains all field specific code outside the classes.
+ */
+
+/**
+ * Implements hook_bundle_fields_info().
+ *
+ * This hook tells Drupal/Tripal about your new field type. Make sure you've created the
+ * field (handles basic storage of your data), widget (provides user UI to set data),
+ * and formatter (describes display of data on Entity Page) classes. These should be
+ * located in the following directory: [your module]/includes/TripalFields/[classname].inc
+ * with one file per class. Your field name should be [cv name]__[cvterm name] and the
+ * classes should be named [field name], [field_name]_widget, [field name]_formatter
+ * for the field, widget and formatter respectively. MAKE SURE YOU'VE CLEARED THE CACHE
+ * SINCE ADDING THESE FILES so Tripal magic can find them or the following will fail.
+ *
+ * @param $entity_type
+ *   This should be 'TripalEntity' for all Tripal Content.
+ * @param $bundle
+ *   This object describes the Type of Tripal Entity (e.g. Organism or Gene) this hook is
+ *   being called for. However, since this hook creates field types (by definition not
+ *   tied to a specific Tripal Content Type (bundle)) and since a field type will only be
+ *   created if it doesn't already exist, this parameter doesn't actually matter.
+ *   NOTE: If you do need to determine the bundle in this hook, we suggest inspecting
+ *   the data_table since the label can be changed by site administrators.
+ *
+ * @return
+ *   An array of field definitions. Each field in this array will be created if it
+ *   doesn't already exist. To trigger create of fields when developing call
+ *   tripal_refresh_bundle_fields() for the specific bundle.
+ */
+
+
+function tripal_analysis_go_bundle_fields_info($entity_type, $bundle) {
+  $fields = array();
+
+  // Because we are expecting data housed in Chado we can use the 'data_table'
+  // property of the bundle to determine if this bundle is really the one
+  // we want the field to be associated with.
+    // First add my term.
+    tripal_insert_cvterm(array(
+      'id' => 'local:go_results',
+      'name' => 'Go results',
+      'cv_name' => 'local',
+      'definition' => 'Go results',
+    ));
+
+    // Then describe the field defined by that term.
+    $field_name = 'local__go_results';
+    $field_type = 'local__go_results';
+    $fields[$field_name] = array(
+      'field_name' => $field_name,
+      'type' => $field_type,
+      'cardinality' => 1,
+      'locked' => FALSE,
+      'storage' => array(
+        'type' => 'field_chado_storage',
+      ),
+    );
+
+  return $fields;
+}
+
+/**
+ * Implements hook_bundle_instances_info().
+ *
+ * This hook tells Drupal/Tripal to create a field instance of a given field type on a
+ * specific Tripal Content type (otherwise known as the bundle). Make sure to implement
+ * hook_bundle_create_fields() to create your field type before trying to create an
+ * instance of that field.
+ *
+ * @param $entity_type
+ *   This should be 'TripalEntity' for all Tripal Content.
+ * @param $bundle
+ *   This object describes the Type of Tripal Entity (e.g. Organism or Gene) the field
+ *   instances are being created for. Thus this hook is called once per Tripal Content Type on your
+ *   site. The name of the bundle is the machine name of the type (e.g. bio_data_1) and
+ *   the label of the bundle (e.g. Organism) is what you see in the interface. Since the
+ *   label can be changed by site admin, we suggest checking the data_table to determine
+ *   if this is the entity you want to add field instances to.
+ * @return
+ *   An array of field instance definitions. This is where you can define the defaults
+ *   for any settings you use in your field. Each entry in this array will be used to
+ *   create an instance of an already existing field.
+ */
+function tripal_analysis_go_bundle_instances_info($entity_type, $bundle) {
+  $instances = array();
+
+    $field_name = 'local__go_results';
+    $field_type = 'local__go_results';
+    $instances[$field_name] =  array(
+      'field_name' => $field_name,
+      'entity_type' => $entity_type,
+      'bundle' => $bundle->name,
+      'label' => 'Go results',
+      'description' => 'Go results',
+      'required' => FALSE,
+      'settings' => array(
+        'term_vocabulary' => 'local',
+        'term_name' => 'Go results',
+        'term_accession' => 'go_results',
+        'auto_attach' => FALSE,
+        'chado_table' => $bundle->data_table,
+        'chado_column' => 'organism_id',
+        'base_table' => $bundle->data_table,
+      ),
+      'widget' => array(
+        'type' => 'local__go_results_widget',
+        'settings' => array(),
+      ),
+      'display' => array(
+        'default' => array(
+          'label' => 'hidden',
+          'type' => 'local__go_results_formatter',
+          'settings' => array(),
+        ),
+      ),
+    );
+
+  return $instances;
+}

--- a/theme/tripal_analysis_go.theme.inc
+++ b/theme/tripal_analysis_go.theme.inc
@@ -65,7 +65,7 @@ function tripal_analysis_go_load_organism_go_summary($node) {
 * @param $node
 *
 */
-function tripal_analysis_go_select_form($form, $form_state, $node) {
+function tripal_analysis_go_select_form($form, $form_state, $organism_id) {
 
   $form = array();
 
@@ -78,20 +78,15 @@ function tripal_analysis_go_select_form($form, $form_state, $node) {
     AND GO.analysis_id = a.analysis_id
     ORDER BY GO.analysis_id DESC
   ";
-  $results = chado_query($sql, array(':organism_id' => $node->organism->organism_id));
+  $results = chado_query($sql, array(':organism_id' => $organism_id));
 
   // now build the list of analyses to use in the drop down element
   $analyses = array();
   $analyses[''] = '';
-  while ($analysis = $results->fetchObject()) {
-    # check to see if the user has permission to see this analysis
-    $nid = chado_get_nid_from_id('analysis', $analysis->analysis_id);
-    $anode = node_load($nid);
-    if (node_access("view", $anode)) {
-      $analyses[$analysis->analysis_id."-".$node->organism->organism_id] = "$analysis->name";
-    }
-  }
 
+  while ($analysis = $results->fetchObject()) {
+    $analyses[$analysis->analysis_id."-".$organism_id] = "$analysis->name";
+  }
   // now generate the select box
   $form['tripal_analysis_go_select'] = array(
     '#title' => t('Select a GO report to view'),

--- a/theme/tripal_analysis_go.theme.inc
+++ b/theme/tripal_analysis_go.theme.inc
@@ -65,7 +65,12 @@ function tripal_analysis_go_load_organism_go_summary($node) {
 * @param $node
 *
 */
-function tripal_analysis_go_select_form($form, $form_state, $organism_id) {
+function tripal_analysis_go_select_form($form, $form_state, $node=null, $organism_id="") {
+
+  // To maintain compatibility, just in case
+  if(isset($node)){
+    $organism_id = $node->organism->organism_id;
+  };
 
   $form = array();
 

--- a/theme/tripal_analysis_go.theme.inc
+++ b/theme/tripal_analysis_go.theme.inc
@@ -65,12 +65,7 @@ function tripal_analysis_go_load_organism_go_summary($node) {
 * @param $node
 *
 */
-function tripal_analysis_go_select_form($form, $form_state, $node=null, $analyses=array(), $organism_id="") {
-
-  // To maintain compatibility, just in case
-  if(isset($node)){
-    $organism_id = $node->organism->organism_id;
-  };
+function tripal_analysis_go_select_form($form, $form_state, $node=null, $analyses=array()) {
 
   $form = array();
 
@@ -78,6 +73,7 @@ function tripal_analysis_go_select_form($form, $form_state, $node=null, $analyse
   // in the go_count_analysis materialized view
   // Only do this if it was not done in backend (Tripal 2 case)
   if(isset($node)){
+    $organism_id = $node->organism->organism_id;
     $sql = "
       SELECT *
       FROM {go_count_analysis} GO, {analysis} a

--- a/theme/tripal_analysis_go.theme.inc
+++ b/theme/tripal_analysis_go.theme.inc
@@ -100,7 +100,6 @@ function tripal_analysis_go_select_form($form, $form_state, $node=null, $analyse
       'callback' => "tripal_analysis_go_org_report",
       'wrapper' => 'tripal-analyis-go-report',
       'effect'   => 'fade',
-      'method'   => 'replace',
     ),
     '#suffix' => '<div id="tripal-analyis-go-report"></div>'
   );

--- a/theme/tripal_analysis_go.theme.inc
+++ b/theme/tripal_analysis_go.theme.inc
@@ -65,7 +65,7 @@ function tripal_analysis_go_load_organism_go_summary($node) {
 * @param $node
 *
 */
-function tripal_analysis_go_select_form($form, $form_state, $node=null, $organism_id="") {
+function tripal_analysis_go_select_form($form, $form_state, $node=null, $analyses=array(), $organism_id="") {
 
   // To maintain compatibility, just in case
   if(isset($node)){
@@ -76,21 +76,23 @@ function tripal_analysis_go_select_form($form, $form_state, $node=null, $organis
 
   // find analyses that have GO terms and their organisms.  this is kept
   // in the go_count_analysis materialized view
-  $sql = "
-    SELECT *
-    FROM {go_count_analysis} GO, {analysis} a
-    WHERE organism_id = :organism_id
-    AND GO.analysis_id = a.analysis_id
-    ORDER BY GO.analysis_id DESC
-  ";
-  $results = chado_query($sql, array(':organism_id' => $organism_id));
+  // Only do this if it was not done in backend (Tripal 2 case)
+  if(isset($node)){
+    $sql = "
+      SELECT *
+      FROM {go_count_analysis} GO, {analysis} a
+      WHERE organism_id = :organism_id
+      AND GO.analysis_id = a.analysis_id
+      ORDER BY GO.analysis_id DESC
+    ";
+    $results = chado_query($sql, array(':organism_id' => $organism_id));
 
-  // now build the list of analyses to use in the drop down element
-  $analyses = array();
-  $analyses[''] = '';
+    // now build the list of analyses to use in the drop down element
+    $analyses[''] = '';
 
-  while ($analysis = $results->fetchObject()) {
-    $analyses[$analysis->analysis_id."-".$organism_id] = "$analysis->name";
+    while ($analysis = $results->fetchObject()) {
+      $analyses[$analysis->analysis_id."-".$organism_id] = "$analysis->name";
+    }
   }
   // now generate the select box
   $form['tripal_analysis_go_select'] = array(

--- a/tripal_analysis_go.info
+++ b/tripal_analysis_go.info
@@ -7,3 +7,4 @@ package = Tripal Extensions
 
 dependencies[] = tripal
 dependencies[] = tripal_chado
+dependencies[] = tripal_cv

--- a/tripal_analysis_go.info
+++ b/tripal_analysis_go.info
@@ -7,4 +7,3 @@ package = Tripal Extensions
 
 dependencies[] = tripal
 dependencies[] = tripal_chado
-dependencies[] = tripal_cv

--- a/tripal_analysis_go.install
+++ b/tripal_analysis_go.install
@@ -176,17 +176,16 @@ function tripal_analysis_go_uninstall(){
   }
 }
 
-/*******************************************************************************
- * Implementation of hook_requirements(). Make sure 'Tripal Core' and 'Tripal
- * Analysis' are enabled before installation
+/**
+ * Implements hook_requirements
  */
 function tripal_analysis_go_requirements($phase) {
   $requirements = array();
   if ($phase == 'install') {
     // make sure chado is installed
     if (!$GLOBALS["chado_is_installed"]) {
-      $requirements ['tripal_feature'] = array(
-          'title' => "t ripal_feature",
+      $requirements ['tripal_analysis_go'] = array(
+          'title' => "tripal_analysis_go",
           'value' => "ERROR: Chado must be installed before this module can be enabled",
           'severity' => REQUIREMENT_ERROR,
       );

--- a/tripal_analysis_go.module
+++ b/tripal_analysis_go.module
@@ -61,7 +61,7 @@ function tripal_analysis_go_init(){
  */
 function tripal_analysis_go_menu() {
   $items = array();
-
+/*
   $items['admin/tripal/extension/tripal_go_analysis'] = array(
     'title' => 'GO Analyses',
     'description' => 'Administrative pages for the Tripal GO Analysis module.',
@@ -88,6 +88,7 @@ function tripal_analysis_go_menu() {
     'type' => MENU_LOCAL_TASK,
     'weight' => 2
   );
+*/
   $items['download_goterm_features'] = array(
       'path' => 'download_goterm_features',
       'title' => t('Get GO Term Features'),

--- a/tripal_analysis_go.module
+++ b/tripal_analysis_go.module
@@ -56,26 +56,6 @@ function tripal_analysis_go_init(){
   ));
 }
 
-
-/**
- * Implements hook_requirements
- */
-function tripal_analysis_go_requirements($phase) {
-  $requirements = array();
-  if ($phase == 'install') {
-    // make sure chado is installed
-    if (!$GLOBALS["chado_is_installed"]) {
-      $requirements ['tripal_analysis_go'] = array(
-          'title' => "tripal_analysis_go",
-          'value' => "ERROR: Chado must be installed before this module can be enabled",
-          'severity' => REQUIREMENT_ERROR,
-      );
-    }
-  }
-  return $requirements;
-}
-
-
 /**
  * Implements hook_menu().
  */

--- a/tripal_analysis_go.module
+++ b/tripal_analysis_go.module
@@ -6,6 +6,7 @@ require_once "includes/tripal_analysis_go.admin.inc";
 require_once "includes/tripal_analysis_go.chado_node.inc";
 require_once "includes/tripal_analysis_go.chart.inc";
 require_once "includes/tripal_analysis_go.tree.inc";
+require_once "includes/tripal_analysis_go.fields.inc";
 require_once "theme/tripal_analysis_go.theme.inc";
 
 

--- a/tripal_analysis_go.module
+++ b/tripal_analysis_go.module
@@ -61,6 +61,7 @@ function tripal_analysis_go_init(){
  */
 function tripal_analysis_go_menu() {
   $items = array();
+  //Deprecated in Tripal 2
 /*
   $items['admin/tripal/extension/tripal_go_analysis'] = array(
     'title' => 'GO Analyses',
@@ -89,6 +90,42 @@ function tripal_analysis_go_menu() {
     'weight' => 2
   );
 */
+
+  $items['tripal_cv_chart'] = array(
+    'path' => 'tripal_cv_chart',
+    'page callback' => 'tripal_cv_chart',
+    'page arguments' => array(1),
+    'access arguments' => array('access content'),
+    'type' => MENU_CALLBACK
+  );
+
+  $items['tripal_cv_tree'] = array(
+    'path' => 'tripal_cv_tree',
+    'page callback' => 'tripal_cv_tree',
+    'page arguments' => array(1),
+    'access arguments' => array('access content'),
+    'type' => MENU_CALLBACK
+  );
+
+  // menu item for interaction with the tree
+  $items['tripal_cv_update_tree'] = array(
+    'path' => 'tripal_cv_update_tree',
+    'page callback' => 'tripal_cv_update_tree',
+    'page arguments' => array(2, 3),
+    'access arguments' => array('access content'),
+    'type' => MENU_CALLBACK
+  );
+
+  // menu items for working with terms
+  $items['tripal_cv_cvterm_info'] = array(
+    'path' => 'tripal_cv_cvterm_info',
+    'title' => 'CV Term Viewer',
+    'page callback' => 'tripal_cv_cvterm_info',
+    'page arguments' => array(1),
+    'access arguments' => array('access content'),
+    'type' => MENU_CALLBACK
+  );
+
   $items['download_goterm_features'] = array(
       'path' => 'download_goterm_features',
       'title' => t('Get GO Term Features'),

--- a/tripal_analysis_go.module
+++ b/tripal_analysis_go.module
@@ -56,6 +56,26 @@ function tripal_analysis_go_init(){
   ));
 }
 
+
+/**
+ * Implements hook_requirements
+ */
+function tripal_analysis_go_requirements($phase) {
+  $requirements = array();
+  if ($phase == 'install') {
+    // make sure chado is installed
+    if (!$GLOBALS["chado_is_installed"]) {
+      $requirements ['tripal_analysis_go'] = array(
+          'title' => "tripal_analysis_go",
+          'value' => "ERROR: Chado must be installed before this module can be enabled",
+          'severity' => REQUIREMENT_ERROR,
+      );
+    }
+  }
+  return $requirements;
+}
+
+
 /**
  * Implements hook_menu().
  */


### PR DESCRIPTION
Hello,

As per #11 , I added a field for the organism entity which include the charts.
To be honest, it's a bandaid fix, there are a lot of things to be done in order to properly support Tripal3.
But for now, it helps providing basic support.

Modifications : 

- Added the field for organisms. It still needs to be activated by the admin.
- 'Removed' the config and sync pages for the module (it throws exceptions.. an overhaul would be required to make it functional gain
- Added tripal_cv requirement (needed for the graphs)
- Bypassed the 'node' calls in the graph form (replaced by organism id)

A lot more cleanup could be done, but for now it's functional.

![image](https://user-images.githubusercontent.com/17642511/50888413-e4ea8200-13f5-11e9-8f85-f6ee3e6c165a.png)


